### PR TITLE
Add support for cloud-based full object specs

### DIFF
--- a/src/main/java/com/codicesoftware/plasticscm/plugins/mergebot/jenkins/UpdateToSpec.java
+++ b/src/main/java/com/codicesoftware/plasticscm/plugins/mergebot/jenkins/UpdateToSpec.java
@@ -34,7 +34,7 @@ public class UpdateToSpec {
 
         String[] parts = updateToSpecStr.split("@");
 
-        if (parts.length != 3)
+        if (parts.length < 3 || parts.length > 4)
             throw new AbortException(
                 "Update spec requires an object name, a rep name and a server name, separated by '@' character.");
 
@@ -42,6 +42,8 @@ public class UpdateToSpec {
         spec.fullObjectSpec = updateToSpecStr;
         spec.repName = parts[1];
         spec.repServer = parts[2];
+        if (parts.length == 4)
+          spec.repServer += "@" + parts[3];
 
         if (!parseObjectSpec(parts[0], spec))
             throw new AbortException(


### PR DESCRIPTION
Digest not only on-prem full object specs (`br:/main/scm009@rep@server:port`) but also cloud-based full object specs (`br:/main/scm009@rep@my_org@cloud`).

The `@` splitting should consider a cloud spec that contains an extra `@` separator.