### PR TITLE
Deprecate plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## Deprecation (02 Jan 2024)
+
+This plugin is no longer relevant.
+
 ## Version 0.16 (21 Dec 2022)
 
 * Support object specs for cloud-based repos.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# :warning: Deprecation notice
+
+> :warning: WARNING :warning:
+>
+> This plugin is deprecated. Its functionality has been integrated into the
+> [Plastic SCM plugin](https://plugins.jenkins.io/plasticscm-plugin/).
+> Please update your projects to use the Plastic SCM plugin instead.
+
 <h1 align="center">
   <img src="doc/img/logo-plasticscm.svg" alt="Plastic SCM Logo" width="450" />
 </h1>


### PR DESCRIPTION
# Deprecation notice

This plugin provided a specific functionality related to Plastic SCM mergebots and plugs. It was a lightweight plugin that duplicated some of the code existing in the main [Plastic SCM plugin for Jenkins](https://github.com/jenkinsci/plasticscm-plugin).

As we kept on adding features to the main plugin, this one stayed behind. Not only in improvements, but also in bugfixes that applied to that duplicated common code.

We decided that the best course of action was to port over the Mergebot functionality -that this plugin provides- over to the main plugin.

This has a few advantages: both ways of working with Plastic SCM use the same underlying code to communicate with the CLI, codebase is tighter and we can apply improvements (e.g. Plastic SCM CLI as Jenkins Tool) to both workflows.

The result is the deprecation of this plugin. We recommend you to replace it with the latest version of the main Plastic SCM Plugin. There won't be any further updates to this `plasticscm-mergebot-plugin`.